### PR TITLE
Find position closest to the requested column

### DIFF
--- a/parsing/Line.php
+++ b/parsing/Line.php
@@ -240,7 +240,17 @@ class Line
      */
     public function getPosition($column)
     {
-        return isset($this->positions[$column]) ? $this->positions[$column] : null;
+        if (isset($this->positions[$column])) {
+            return $this->positions[$column];
+        }
+        $prev = null;
+        foreach ($this->positions as $idx => $position) {
+            if ($position->generated->column > $column) {
+                return $prev;
+            }
+            $prev = $position;
+        }
+        return null;
     }
 
     /**
@@ -278,8 +288,9 @@ class Line
         $fg = $filter->generated;
         $positions = $this->positions;
         if ($fg->column !== null) {
-            if (isset($positions[$fg->column])) {
-                $positions = [$positions[$fg->column]];
+            $position = $this->getPosition($fg->column);
+            if ($position) {
+                $positions = [$position];
             }
         }
         $fs = $filter->source;


### PR DESCRIPTION
When dealing with JavaScript errors the reported error position ignores leading spaces, other expressions on the same line and so on.
Currently `Line::getPosition` returns `PosMap` only if you request position exactly matching first column of source line, so, for example, if you have `$this->positions` with indexes `0, 10, 30, 70` and you request column 25, you'll get `null` instead of   `PosMap->generated->column === 10`.

There may be a room for further improvements, like shifting source column to point exactly at requested column, in example that's +15 chars to the right.