### PR TITLE
Fix 'using null as an array offset is deprecated' on PHP 8.5

### DIFF
--- a/src/parsing/Line.php
+++ b/src/parsing/Line.php
@@ -489,10 +489,10 @@ class Line
             $generated->column += $dColumn;
             $fi = $source->fileIndex;
             $ni = $source->nameIndex;
-            if ((isset($mSources[$fi])) && ($fi !== null)) {
+            if (($fi !== null) && (isset($mSources[$fi]))) {
                 $source->fileIndex = $mSources[$fi];
             }
-            if ((isset($mNames[$ni])) && ($ni !== null)) {
+            if (($ni !== null) && (isset($mNames[$ni]))) {
                 $source->nameIndex = $mNames[$ni];
             }
             $npos[$generated->column] = $position;


### PR DESCRIPTION
`Line::concat()` tests the array before it tests the index:

```php
$fi = $source->fileIndex;
$ni = $source->nameIndex;
if ((isset($mSources[$fi])) && ($fi !== null)) {
    $source->fileIndex = $mSources[$fi];
}
if ((isset($mNames[$ni])) && ($ni !== null)) {
    $source->nameIndex = $mNames[$ni];
}
```

`isset($mSources[$fi])` evaluates the offset first, so with `$fi` null the `$fi !== null` check is never reached — it can't do anything. `$fi` and `$ni` are null whenever a position has no source file or no name, which is routine, and PHP 8.5 reports every occurrence:

```
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in src/parsing/Line.php on line 495
```

Swapping the operands can't change behaviour, since `isset()` on a null offset is already false.

I found this in Flarum, where we concatenate a sourcemap per asset when building the frontend bundle. On a debug install with `display_errors` on it's hundreds of lines per request — flarum/framework#4894 has the detail.

### Checks

- Test suite passes on 8.1, 8.2, 8.3, 8.4 and 8.5 — 147 tests, 387 assertions.
- `concat()` output is byte-identical before and after, same input.
- No deprecations left in `src` on 8.5. The 7 that remain are all in `axy/errors` and `axy/codecs-base64vlq`, which I've mentioned in the issue.
- `phpcs` clean.

Closes #12
